### PR TITLE
Added .plugin file for oh-my-zsh support

### DIFF
--- a/mac-zsh-completions.plugin.zsh
+++ b/mac-zsh-completions.plugin.zsh
@@ -1,0 +1,1 @@
+fpath+="${0:h}/completions"


### PR DESCRIPTION
Allows easier use for users of Antigen and oh-my-zsh via plugin support.
I can add to the ReadMe to specify how to use it for that as well.