### PR TITLE
Fix the install docs git clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ fpath=( ~/Projects/mac-zsh-completions/completions $fpath )
 ### Install via [oh-my-zsh](https://github.com/robbyrussell/oh-my-zsh/)
 
 ```zsh
-git clone git@github.com:scriptingosx/mac-zsh-completions.git "$ZSH_CUSTOM/plugins/mac-zsh-completions"
+git clone https://github.com/scriptingosx/mac-zsh-completions.git "$ZSH_CUSTOM/plugins/mac-zsh-completions"
 ```
 
 - Add to your `~/.zshrc` plugins array `plugins=(... mac-zsh-completions)`


### PR DESCRIPTION
Git cloning via SSH has authentication issues for those that don't have keys setup. HTTPS works with public repos.